### PR TITLE
Add upload_feed_document method

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ upload_url = response.parse["url"]
 
 # Upload the feed content to the provided URL
 feed_content = File.read("inventory_update.xml")
-api.upload_feed_document(upload_url, feed_content)
+api.upload_feed_document(upload_url, feed_content, "text/xml; charset=UTF-8")
 
 # Create the feed
 response = api.create_feed(

--- a/lib/generator/api.rb
+++ b/lib/generator/api.rb
@@ -42,6 +42,18 @@ module Generator
       "peddler/api/#{name_with_version}"
     end
 
+    def has_helper?
+      File.exist?("lib/" + helper_library_name + ".rb")
+    end
+
+    def helper_class_name
+      "Peddler::Helpers::#{pascalcase(name_with_version)}"
+    end
+
+    def helper_library_name
+      "peddler/helpers/#{name_with_version}"
+    end
+
     def class_name
       pascalcase(name_with_version)
     end

--- a/lib/peddler/api/feeds_2021_06_30.rb
+++ b/lib/peddler/api/feeds_2021_06_30.rb
@@ -2,6 +2,8 @@
 
 require "peddler/api"
 
+require "peddler/helpers/feeds_2021_06_30"
+
 module Peddler
   class << self
     def feeds_2021_06_30(...)
@@ -14,6 +16,8 @@ module Peddler
     #
     # The Selling Partner API for Feeds lets you upload data to Amazon on behalf of a selling partner.
     class Feeds20210630 < API
+      include Peddler::Helpers::Feeds20210630
+
       # Returns feed details for the feeds that match the filters that you specify.
       #
       # @note This operation can make a static sandbox call.

--- a/lib/peddler/helpers/feeds_2021_06_30.rb
+++ b/lib/peddler/helpers/feeds_2021_06_30.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Peddler
+  module Helpers
+    module Feeds20210630
+      # Uploads feed_content to a signed upload_url previously provided by
+      # create_feed_document. The upload_url is signed, the Host and content-type
+      # headers must match the signing.
+      # @param upload_url [String] The signed url from the `create_feed_document` response.
+      # @param feed_content [String] The body of the content to upload.
+      # @param content_type [String] The content type of the upload,
+      # this must match the content-type requested in `create_feed_document`
+      # @return [HTTP::Response] The API response
+      def upload_feed_document(upload_url, feed_content, content_type)
+        response = HTTP.headers(
+          "Host" => URI.parse(upload_url).host,
+          "content-type" => content_type,
+        ).send(:put, upload_url, body: feed_content)
+
+        if response.status.client_error?
+          error = Error.build(response)
+          raise error if error
+        end
+
+        response
+      end
+    end
+  end
+end

--- a/templates/api.rb.erb
+++ b/templates/api.rb.erb
@@ -1,5 +1,8 @@
 
 require "peddler/api"
+<% if has_helper? %>
+  require "<%= helper_library_name %>"
+<% end %>
 
 module Peddler
   class << self
@@ -13,6 +16,9 @@ module Peddler
     #
     <%= description %>
     class <%= class_name %> < API
+      <% if has_helper? %>
+        include <%= helper_class_name %>
+      <% end %>
       <% operations.each do |operation| %>
         <%= operation.render %>
       <% end %>


### PR DESCRIPTION
This method has previously been mentioned in the README, but was not defined. This PR defines the method, with an additional parameter to take the user requested content-type, which must match due to the signed headers.

Additionally, I noticed that API methods claim in their YARD docs to return a `Hash` but actually return an `HTTP::Response` which must be called with `.parse` to access a `Hash` version of the response.
I indicated this in line the functionality in the new YARD docs I wrote, but it may be useful to update existing occurrences elsewhere in the gem.