### PR TITLE
Set the failed http response in a custom attribute instead of `cause`

### DIFF
--- a/lib/peddler/error.rb
+++ b/lib/peddler/error.rb
@@ -7,7 +7,7 @@ module Peddler
     class QuotaExceeded < Error; end
     class Unauthorized < Error; end
 
-    attr_reader :cause
+    attr_reader :response
 
     # @!visibility private
     class << self
@@ -23,8 +23,8 @@ module Peddler
       end
     end
 
-    def initialize(msg = nil, cause = nil)
-      @cause = cause
+    def initialize(msg = nil, response = nil)
+      @response = response
       super(msg)
     end
   end


### PR DESCRIPTION
`#cause` in a custom error should return the expected class. This commit updates the custom value that is useful to store, the response, to use a specific name rather than overriding `#cause`’s behavior.

Ruby documentation explains that the default expectation of `#cause` is that it will return either `an_exception` or `nil`. By setting an `HTTP::Response` to return from `#cause`, tools utilizing it may expect to send messages that may fail.

https://ruby-doc.org/3.2.6/Exception.html#method-i-cause

Specifically, I experienced a `NoMethodError: undefined method 'backtrace'` when an error occurred within `pry`.

![image](https://github.com/user-attachments/assets/25c93127-7e49-4be7-8e3f-498bff378813)
