### PR TITLE
Simplify dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -15,51 +15,17 @@ jobs:
         uses: dependabot/fetch-metadata@v2
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Approve PR
+        if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' }}
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Enable auto-merge for Dependabot PRs
         if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' }}
-        uses: actions/github-script@v7
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-          script: |
-            const getPullRequestIdQuery = `query GetPullRequestId($owner: String!, $repo: String!, $pullRequestNumber: Int!) {
-              repository(owner: $owner, name: $repo) {
-                pullRequest(number: $pullRequestNumber) {
-                  id
-                }
-              }
-            }`
-            const repoInfo = {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pullRequestNumber: context.issue.number,
-            }
-            const response = await github.graphql(getPullRequestIdQuery, repoInfo)
-
-            await github.rest.pulls.createReview({
-              pull_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              event: 'APPROVE',
-            })
-
-            const enableAutoMergeQuery = `mutation ($pullRequestId: ID!, $mergeMethod: PullRequestMergeMethod!) {
-              enablePullRequestAutoMerge(input: {
-                pullRequestId: $pullRequestId,
-                mergeMethod: $mergeMethod
-              }) {
-                pullRequest {
-                  autoMergeRequest {
-                    enabledAt
-                    enabledBy {
-                      login
-                    }
-                  }
-                }
-              }
-            }`
-            const data = {
-              pullRequestId: response.repository.pullRequest.id,
-              mergeMethod: 'SQUASH',
-            }
-
-            await github.graphql(enableAutoMergeQuery, data)
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Replace complex GraphQL queries with simple GitHub CLI commands.

This change:
- Makes the workflow more readable and maintainable
- Separates approval and auto-merge into distinct steps for better debugging
- Uses built-in GitHub CLI instead of external actions
- Achieves the same functionality with much cleaner code

The new approach is simpler, easier to understand, and less prone to breaking changes.