### PR TITLE
refactor: rename response.decorate to response.wrap and consolidate error handling

### DIFF
--- a/lib/peddler/api.rb
+++ b/lib/peddler/api.rb
@@ -124,7 +124,7 @@ module Peddler
 
         response = http.send(method, uri, **options)
 
-        Response.decorate(response, parser:)
+        Response.wrap(response, parser:)
       end
     end
 

--- a/lib/peddler/helpers/feeds_2021_06_30.rb
+++ b/lib/peddler/helpers/feeds_2021_06_30.rb
@@ -20,7 +20,7 @@ module Peddler
       def upload_feed_document(upload_url, feed_content, content_type)
         response = HTTP.headers("content-type" => content_type).put(upload_url, body: feed_content)
 
-        Response.decorate(response, parser:)
+        Response.wrap(response, parser:)
       end
 
       # Convenience method to download result feed content from a signed download_url
@@ -33,7 +33,7 @@ module Peddler
       def download_result_feed_document(download_url)
         response = HTTP.get(download_url)
 
-        Response.decorate(response, parser:)
+        Response.wrap(response, parser:)
       end
     end
   end

--- a/lib/peddler/helpers/reports_2021_06_30.rb
+++ b/lib/peddler/helpers/reports_2021_06_30.rb
@@ -30,7 +30,7 @@ module Peddler
       def download_report_document_from_url(download_url)
         response = HTTP.get(download_url)
 
-        Response.decorate(response, parser:)
+        Response.wrap(response, parser:)
       end
     end
   end

--- a/lib/peddler/response.rb
+++ b/lib/peddler/response.rb
@@ -55,7 +55,7 @@ module Peddler
       def wrap(response, parser: nil)
         if response.status.client_error? || response.status.server_error?
           error = Error.build(response)
-          error ? raise(error) : raise(Error.new("#{response.status.code} #{response.status.reason}", response))
+          error ? raise(error) : raise(Error.new(response.status, response))
         end
 
         new(response).tap do |wrapper|

--- a/lib/peddler/response.rb
+++ b/lib/peddler/response.rb
@@ -55,7 +55,7 @@ module Peddler
       def wrap(response, parser: nil)
         if response.status.client_error? || response.status.server_error?
           error = Error.build(response)
-          error ? raise(error) : raise(Error.new("Unexpected status code #{response.status.code}", response))
+          error ? raise(error) : raise(Error.new("#{response.status.code} #{response.status.reason}", response))
         end
 
         new(response).tap do |wrapper|
@@ -64,8 +64,9 @@ module Peddler
       end
 
       # @deprecated Use {.wrap} instead
-      def decorate(response, parser: nil)
-        wrap(response, parser: parser)
+      def decorate(...)
+        warn("Response.decorate is deprecated and will be removed in v5.0. Use Response.wrap instead.", uplevel: 1)
+        wrap(...)
       end
     end
 

--- a/lib/peddler/response.rb
+++ b/lib/peddler/response.rb
@@ -11,7 +11,7 @@ require "peddler/error"
 # HTTP::StatusError for client/server errors. This would simplify our error handling:
 #
 # Current approach:
-#   - Manually check response.status.client_error? in Response.decorate
+#   - Manually check response.status.client_error? in Response.wrap
 #   - Parse error response body to create specific Peddler::Error subclasses
 #   - Fall back to raising generic Peddler::Error if parsing fails (e.g., no Nokogiri)
 #
@@ -46,21 +46,26 @@ module Peddler
     def_delegator :to_h, :dig
 
     class << self
-      # Decorates an HTTP::Response with error handling
+      # Wraps an HTTP::Response with error handling and parsing capabilities
       #
       # @param [HTTP::Response] response
       # @param [nil, #call] parser (if any)
-      # @return [ResponseDecorator]
+      # @return [Response]
       # @raise [Peddler::Error] if response has client or server error status
-      def decorate(response, parser: nil)
+      def wrap(response, parser: nil)
         if response.status.client_error? || response.status.server_error?
           error = Error.build(response)
           error ? raise(error) : raise(Error.new("Unexpected status code #{response.status.code}", response))
         end
 
-        new(response).tap do |decorator|
-          decorator.parser = parser
+        new(response).tap do |wrapper|
+          wrapper.parser = parser
         end
+      end
+
+      # @deprecated Use {.wrap} instead
+      def decorate(response, parser: nil)
+        wrap(response, parser: parser)
       end
     end
 

--- a/lib/peddler/token.rb
+++ b/lib/peddler/token.rb
@@ -2,7 +2,6 @@
 
 require "http"
 
-require "peddler/error"
 require "peddler/response"
 
 module Peddler

--- a/lib/peddler/token.rb
+++ b/lib/peddler/token.rb
@@ -3,6 +3,7 @@
 require "http"
 
 require "peddler/error"
+require "peddler/response"
 
 module Peddler
   # Requests refresh and access tokens that authorize your application to take actions on behalf of a selling partner.
@@ -31,13 +32,7 @@ module Peddler
 
     def request
       response = HTTP.post(URL, form: params)
-
-      if response.status.client_error? || response.status.server_error?
-        error = Error.build(response)
-        error ? raise(error) : raise(Error.new("Unexpected status code #{response.status.code}", response))
-      end
-
-      response
+      Response.wrap(response)
     end
 
     def grant_type

--- a/test/peddler/response_test.rb
+++ b/test/peddler/response_test.rb
@@ -81,6 +81,35 @@ module Peddler
       assert_equal(payload, wrapper.parse)
     end
 
+    def test_decorate_deprecation_warning
+      assert_output(nil, /Response\.decorate is deprecated/) do
+        Response.decorate(response)
+      end
+    end
+
+    def test_deprecation_removal_reminder
+      if Gem.loaded_specs["peddler"].version.segments.first >= 5
+        flunk("Response.decorate should have been removed in v5.0. Please delete it now.")
+      end
+    end
+
+    def test_error_message_includes_status_reason
+      response = HTTP::Response.new(
+        body: "plain text error",
+        headers: { "Content-Type" => "text/plain" },
+        status: 404,
+        version: "1.1",
+        request: nil,
+      )
+
+      error = assert_raises(Peddler::Error) do
+        Response.wrap(response)
+      end
+
+      assert_includes(error.message, "404")
+      assert_includes(error.message, "Not Found")
+    end
+
     private
 
     def response

--- a/test/peddler/response_test.rb
+++ b/test/peddler/response_test.rb
@@ -76,7 +76,10 @@ module Peddler
     end
 
     def test_decorate_deprecation_still_works
-      wrapper = Response.decorate(response)
+      wrapper = nil
+      assert_output(nil, /Response\.decorate is deprecated/) do
+        wrapper = Response.decorate(response)
+      end
 
       assert_equal(payload, wrapper.parse)
     end

--- a/test/peddler/response_test.rb
+++ b/test/peddler/response_test.rb
@@ -6,45 +6,45 @@ require "peddler/response"
 module Peddler
   class ResponseTest < Minitest::Test
     def test_parses
-      decorator = Response.decorate(response)
+      wrapper = Response.wrap(response)
 
-      assert_equal(payload, decorator.parse)
+      assert_equal(payload, wrapper.parse)
     end
 
     def test_to_h
-      decorator = Response.decorate(response)
+      wrapper = Response.wrap(response)
 
-      assert_equal(payload, decorator.to_h)
+      assert_equal(payload, wrapper.to_h)
     end
 
     def test_dig
-      decorator = Response.decorate(response)
+      wrapper = Response.wrap(response)
 
-      assert(decorator.dig("foo"))
+      assert(wrapper.dig("foo"))
     end
 
     def test_parses_with_custom_parser
-      decorator = Response.decorate(
+      wrapper = Response.wrap(
         response, parser: ->(response) { JSON.parse(response, symbolize_names: true) }
       )
 
-      assert_equal(payload_with_symbolized_keys, decorator.parse)
+      assert_equal(payload_with_symbolized_keys, wrapper.parse)
     end
 
     def test_to_h_with_custom_parser
-      decorator = Response.decorate(
+      wrapper = Response.wrap(
         response, parser: ->(response) { JSON.parse(response, symbolize_names: true) }
       )
 
-      assert_equal(payload_with_symbolized_keys, decorator.to_h)
+      assert_equal(payload_with_symbolized_keys, wrapper.to_h)
     end
 
     def test_dig_with_custom_parser
-      decorator = Response.decorate(
+      wrapper = Response.wrap(
         response, parser: ->(response) { JSON.parse(response, symbolize_names: true) }
       )
 
-      assert(decorator.dig(:foo))
+      assert(wrapper.dig(:foo))
     end
 
     def test_raises_error_on_client_error
@@ -57,7 +57,7 @@ module Peddler
       )
 
       assert_raises(Peddler::Error) do
-        Response.decorate(response)
+        Response.wrap(response)
       end
     end
 
@@ -71,8 +71,14 @@ module Peddler
       )
 
       assert_raises(Peddler::Error) do
-        Response.decorate(response)
+        Response.wrap(response)
       end
+    end
+
+    def test_decorate_deprecation_still_works
+      wrapper = Response.decorate(response)
+
+      assert_equal(payload, wrapper.parse)
     end
 
     private

--- a/test/peddler/token_test.rb
+++ b/test/peddler/token_test.rb
@@ -29,17 +29,6 @@ module Peddler
       refute_nil(error.response)
     end
 
-    def test_transient_error
-      VCR.eject_cassette if VCR.current_cassette
-      VCR.turned_off do
-        stub_request(:any, /.*/)
-          .to_return(status: 500, body: "Internal Server Error", headers: { "Content-Type" => "text/html" })
-        assert_raises(Peddler::Error) do
-          Token.request(client_id:, client_secret:).parse
-        end
-      end
-    end
-
     def test_obsolete_error_class
       assert(defined?(Token::Error))
       if Gem.loaded_specs["peddler"].version.segments.first >= 5


### PR DESCRIPTION
This PR addresses the naming and consolidation issues discussed around the Response.decorate method.

## Changes

### 1. Renamed  to 
- The verb "wrap" better describes what the method actually does - it wraps HTTP::Response with additional parsing capabilities
- Added backward compatibility through a deprecated  method

### 2. Consolidated error handling in Token class
- Refactored  to use  instead of duplicating error handling logic
- Removed redundant error handling code that was identical to what  provides
- Added  to token.rb

### 3. Updated all references across codebase
- Updated API class to use 
- Updated helper modules (feeds and reports) to use 
- Updated all tests to use new method name
- Added deprecation test to ensure backward compatibility

### 4. Removed redundant tests
- Removed  from token tests since error handling is now covered by the consolidated  method
- This reduces test duplication and maintenance burden

## Benefits

- **Clearer semantics**: "wrap" better expresses the intent than "decorate"
- **DRY principle**: Eliminates duplicated error handling logic between API and Token classes
- **Consistency**: All HTTP response handling now goes through the same error checking pipeline
- **Maintainability**: Error handling logic is centralized in one place

## Breaking Changes

None - the old  method is preserved for backward compatibility (marked as deprecated).

All tests pass and linting is clean.