### PR TITLE
fix: update workflow ruby version and commit format

### DIFF
--- a/.github/workflows/update-amazon-models.yml
+++ b/.github/workflows/update-amazon-models.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.4"
+          ruby-version: "3.2"
           bundler-cache: true
 
       - name: Install dependencies
@@ -40,47 +40,47 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { execSync } = require('child_process');
-            
+
             // Check for changes
             const status = execSync('git status --porcelain', { encoding: 'utf8' });
             if (!status.trim()) {
               console.log('No changes detected, skipping PR creation');
               return;
             }
-            
+
             // Get changed files (excluding untracked)
             const changedFiles = status
               .split('\n')
               .filter(line => line && !line.startsWith('??'))
               .map(line => line.substring(3));
-            
+
             // Extract API names from changed files
             const apiUpdates = changedFiles
               .filter(file => file.match(/lib\/peddler\/apis\/[^\/]*\.rb/))
               .map(file => file.replace(/lib\/peddler\/apis\/(.*)\.rb/, '$1'))
               .filter((name, index, arr) => arr.indexOf(name) === index)
               .sort();
-            
+
             // Configure git
             execSync('git config user.name "github-actions[bot]"');
             execSync('git config user.email "github-actions[bot]@users.noreply.github.com"');
-            
+
             // Create branch with timestamp
             const timestamp = new Date().toISOString().replace(/[-:]/g, '').split('.')[0];
             const branchName = `update-api-${timestamp}`;
             execSync(`git checkout -b ${branchName}`);
-            
-            // Create commit message
-            let commitMessage = 'Update Amazon models';
+
+            // Create commit message with conventional format
+            let commitMessage = 'feat: update amazon api models';
             if (apiUpdates.length > 0) {
               commitMessage += '\n\nUpdated APIs:\n' + apiUpdates.map(api => `- ${api}`).join('\n');
             }
-            
+
             // Commit changes
             execSync('git add -A');
             execSync(`git commit -m "${commitMessage}"`);
             execSync(`git push --set-upstream origin ${branchName}`);
-            
+
             // Create PR title and body
             const today = new Date().toISOString().split('T')[0];
             const prTitle = `Update Amazon models - ${today}`;
@@ -90,7 +90,7 @@ jobs:
             ${changedFiles.map(file => `- ${file}`).join('\n')}
 
             Created by GitHub Actions workflow.`;
-            
+
             // Create PR using GitHub API
             const { data: pr } = await github.rest.pulls.create({
               owner: context.repo.owner,
@@ -100,5 +100,5 @@ jobs:
               head: branchName,
               base: 'main'
             });
-            
+
             console.log(`Created PR #${pr.number}: ${pr.html_url}`);


### PR DESCRIPTION
Minimal fixes to the update-amazon-models workflow:

- **Ruby version**: Changed from 3.4 to 3.2 (matches minimum supported version in gemspec)
- **Commit format**: Use conventional commits for generated commits (follows project guidelines)

These changes maintain the original workflow structure while fixing compatibility and following project conventions.