### PR TITLE
Fix: Restore RuboCop exclude for generated API files

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,7 @@ plugins:
   - rubocop-rake
 inherit_gem:
   rubocop-shopify: rubocop.yml
+inherit_from: ".rubocop_todo.yml"
 
 AllCops:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1,0 +1,10 @@
+# This file contains RuboCop configuration for auto-generated code that should
+# not be modified by RuboCop auto-correction to maintain consistency with the
+# code generation templates.
+
+Layout/EmptyComment:
+  # Generated API files contain empty comment lines that are part of the code
+  # generation template structure. These should not be auto-corrected to avoid
+  # constant diffs when regenerating from Amazon's OpenAPI specs.
+  Exclude:
+    - "lib/peddler/apis/*.rb"


### PR DESCRIPTION
This PR restores the RuboCop exclusion for generated API files that was accidentally removed in commit 3819517.

## Problem
The recent removal of  caused the  cop to start auto-correcting generated API files, removing empty comment lines that are part of the code generation template structure.

## Solution
- Recreated  with proper documentation
- Added back the  exclusion for 
- Updated  to inherit from the todo file

## Impact
This prevents constant diffs when regenerating API files from Amazon's OpenAPI specs, maintaining consistency with the intended code generation output.

Fixes the format-only changes seen in PR #191.