### PR TITLE
Bump Herb to `0.7.4` to fix `rubocop-erb`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,11 +21,7 @@ gem "vcr"
 gem "webmock"
 gem "yard"
 
-# TODO: Remove when below resolves
-# https://github.com/marcoroth/herb/issues/484
-#
-# Force Ruby platform compilation on macOS
-gem "herb", force_ruby_platform: RUBY_PLATFORM.include?("darwin")
+gem "herb", "~> 0.7", ">= 0.7.4"
 
 # TODO: Remove the version guard when Yard handles changes in the new Commonmarker
 # https://github.com/lsegal/yard/issues/1528


### PR DESCRIPTION
After releasing Herb `v0.7.4` issue https://github.com/marcoroth/herb/issues/484 is not resolved and shouldn't crash when using it on macOS 26 when using the precompiled version of the gem.

Sorry for the trouble! 🙏🏼 